### PR TITLE
New API for loading Station XML

### DIFF
--- a/src/main/java/edu/sc/seis/seisFile/fdsnws/stationxml/FDSNStationXML.java
+++ b/src/main/java/edu/sc/seis/seisFile/fdsnws/stationxml/FDSNStationXML.java
@@ -2,6 +2,7 @@ package edu.sc.seis.seisFile.fdsnws.stationxml;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.Reader;
 import java.net.URL;
 import java.util.NoSuchElementException;
 
@@ -230,7 +231,20 @@ public class FDSNStationXML {
     public static URL loadSchemaWithAvailability() {
         return FDSNStationXML.class.getClassLoader().getResource("edu/sc/seis/seisFile/stationxml/fdsn-station+availability-1.0.xsd");
     }
-    
+
+    public static FDSNStationXML loadStationXML(Reader streamReader) throws XMLStreamException, IOException, SeisFileException {
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        XMLEventReader r = factory.createXMLEventReader(streamReader);
+        XMLEvent e = r.peek();
+        while (!e.isStartElement()) {
+            r.nextEvent(); // eat this one
+            e = r.peek(); // peek at the next
+        }
+        System.out.println("StaMessage");
+        FDSNStationXML fdsnStationXML = new FDSNStationXML(r);
+        return fdsnStationXML;
+    }
+
     public static FDSNStationXML loadStationXML(String filename) throws XMLStreamException, IOException, SeisFileException {
         XMLInputFactory factory = XMLInputFactory.newInstance();
         XMLEventReader r = factory.createXMLEventReader(filename, new FileInputStream(filename));

--- a/src/main/java/edu/sc/seis/seisFile/fdsnws/stationxml/FDSNStationXML.java
+++ b/src/main/java/edu/sc/seis/seisFile/fdsnws/stationxml/FDSNStationXML.java
@@ -2,6 +2,8 @@ package edu.sc.seis.seisFile.fdsnws.stationxml;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.util.NoSuchElementException;
@@ -245,17 +247,12 @@ public class FDSNStationXML {
         return fdsnStationXML;
     }
 
+    public static FDSNStationXML loadStationXML(InputStream stream) throws XMLStreamException, IOException, SeisFileException {
+        return loadStationXML(new InputStreamReader(stream));
+    }
+
     public static FDSNStationXML loadStationXML(String filename) throws XMLStreamException, IOException, SeisFileException {
-        XMLInputFactory factory = XMLInputFactory.newInstance();
-        XMLEventReader r = factory.createXMLEventReader(filename, new FileInputStream(filename));
-        XMLEvent e = r.peek();
-        while (!e.isStartElement()) {
-            e = r.nextEvent(); // eat this one
-            e = r.peek(); // peek at the next
-        }
-        System.out.println("StaMessage");
-        FDSNStationXML fdsnStationXML = new FDSNStationXML(r);
-        return fdsnStationXML;
+        return loadStationXML(new FileInputStream(filename));
     }
     
     public static void main(String[] args) throws XMLStreamException, IOException, SeisFileException, JSAPException {

--- a/src/main/java/edu/sc/seis/seisFile/fdsnws/stationxml/FDSNStationXML.java
+++ b/src/main/java/edu/sc/seis/seisFile/fdsnws/stationxml/FDSNStationXML.java
@@ -1,13 +1,16 @@
 package edu.sc.seis.seisFile.fdsnws.stationxml;
 
+import com.martiansoftware.jsap.JSAPException;
+import edu.sc.seis.seisFile.SeisFileException;
+import edu.sc.seis.seisFile.fdsnws.FDSNStationQuerier;
+import edu.sc.seis.seisFile.fdsnws.StationClient;
+import edu.sc.seis.seisFile.fdsnws.StaxUtil;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
-import java.util.NoSuchElementException;
-
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -15,20 +18,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
-
 import org.apache.http.client.methods.CloseableHttpResponse;
-
-import com.martiansoftware.jsap.JSAPException;
-
-import edu.sc.seis.seisFile.SeisFileException;
-import edu.sc.seis.seisFile.fdsnws.FDSNStationQuerier;
-import edu.sc.seis.seisFile.fdsnws.StationClient;
-import edu.sc.seis.seisFile.fdsnws.StaxUtil;
-import edu.sc.seis.seisFile.fdsnws.quakeml.Quakeml;
-import edu.sc.seis.seisFile.fdsnws.stationxml.Network;
-import edu.sc.seis.seisFile.fdsnws.stationxml.NetworkIterator;
-import edu.sc.seis.seisFile.fdsnws.stationxml.StationXMLException;
-import edu.sc.seis.seisFile.fdsnws.stationxml.StationXMLTagNames;
 
 public class FDSNStationXML {
 
@@ -40,33 +30,41 @@ public class FDSNStationXML {
         if (schemaLocAttr != null) {
             xmlSchemaLocation = schemaLocAttr.getValue();
         } else {
-            xmlSchemaLocation = StationXMLTagNames.CURRENT_SCHEMALOCATION_VERSION+" "+StationXMLTagNames.CURRENT_SCHEMALOCATION_LOCATION;
+            xmlSchemaLocation = StationXMLTagNames.CURRENT_SCHEMALOCATION_VERSION + " " + StationXMLTagNames.CURRENT_SCHEMALOCATION_LOCATION;
         }
         schemaVersion = StaxUtil.pullAttribute(startE, StationXMLTagNames.SCHEMAVERSION);
+        OUTER:
         while (reader.hasNext()) {
             XMLEvent e = reader.peek();
             if (e.isStartElement()) {
                 String elName = e.asStartElement().getName().getLocalPart();
-                if (elName.equals(StationXMLTagNames.SOURCE)) {
-                    source = StaxUtil.pullText(reader, StationXMLTagNames.SOURCE);
-                } else if (elName.equals(StationXMLTagNames.SENDER)) {
-                    sender = StaxUtil.pullText(reader, StationXMLTagNames.SENDER);
-                } else if (elName.equals(StationXMLTagNames.MODULE)) {
-                    module = StaxUtil.pullText(reader, StationXMLTagNames.MODULE);
-                } else if (elName.equals(StationXMLTagNames.MODULEURI)) {
-                    moduleUri = StaxUtil.pullText(reader, StationXMLTagNames.MODULEURI);
-                } else if (elName.equals(StationXMLTagNames.CREATED)) {
-                    created = StaxUtil.pullText(reader, StationXMLTagNames.CREATED);
-                } else if (elName.equals(StationXMLTagNames.NETWORK)) {
-                    networks = new NetworkIterator(reader);
-                    break;
-                } else {
-                    StaxUtil.skipToMatchingEnd(reader);
+                switch (elName) {
+                    case StationXMLTagNames.SOURCE:
+                        source = StaxUtil.pullText(reader, StationXMLTagNames.SOURCE);
+                        break;
+                    case StationXMLTagNames.SENDER:
+                        sender = StaxUtil.pullText(reader, StationXMLTagNames.SENDER);
+                        break;
+                    case StationXMLTagNames.MODULE:
+                        module = StaxUtil.pullText(reader, StationXMLTagNames.MODULE);
+                        break;
+                    case StationXMLTagNames.MODULEURI:
+                        moduleUri = StaxUtil.pullText(reader, StationXMLTagNames.MODULEURI);
+                        break;
+                    case StationXMLTagNames.CREATED:
+                        created = StaxUtil.pullText(reader, StationXMLTagNames.CREATED);
+                        break;
+                    case StationXMLTagNames.NETWORK:
+                        networks = new NetworkIterator(reader);
+                        break OUTER;
+                    default:
+                        StaxUtil.skipToMatchingEnd(reader);
+                        break;
                 }
             } else if (e.isEndElement()) {
                 return;
             } else {
-                e = reader.nextEvent();
+                reader.nextEvent();
             }
         }
     }
@@ -116,12 +114,12 @@ public class FDSNStationXML {
                 public Network next() throws XMLStreamException, StationXMLException {
                     throw new StationXMLException("No mo networks");
                 }
-                
+
             };
         }
         return networks;
     }
-    
+
     public void closeReader() {
         if (fdsnStationQuerier != null) {
             fdsnStationQuerier.close();
@@ -130,7 +128,7 @@ public class FDSNStationXML {
         if (reader != null) {
             try {
                 reader.close();
-            } catch(XMLStreamException e) {
+            } catch (XMLStreamException e) {
                 logger.warn("problem closing underlying XMLEventReader.", e);
             }
         }
@@ -138,57 +136,51 @@ public class FDSNStationXML {
         if (response != null) {
             try {
                 response.close();
-            } catch(IOException e) {
+            } catch (IOException e) {
                 getLogger().warn("trouble closing HttpResponse", e);
             }
         }
         response = null;
     }
-    
-    
+
     public String getXmlSchemaLocation() {
         return xmlSchemaLocation;
     }
 
-    
     public void setXmlSchemaLocation(String xmlns) {
         this.xmlSchemaLocation = xmlns;
     }
-    
-    
+
     public XMLEventReader getReader() {
         return reader;
     }
 
-    
     public String getModuleUri() {
         return moduleUri;
     }
 
-    
     public String getSchemaVersion() {
         return schemaVersion;
     }
 
-    
     public static org.slf4j.Logger getLogger() {
         return logger;
     }
 
     public boolean checkSchemaVersion() {
-        if ( ! xmlSchemaLocation.split(" ")[0].equals(StationXMLTagNames.CURRENT_SCHEMALOCATION_VERSION)) {
+        if (!xmlSchemaLocation.split(" ")[0].equals(StationXMLTagNames.CURRENT_SCHEMALOCATION_VERSION)) {
             return false;
         }
-        if ( ! StationXMLTagNames.CURRENT_SCHEMA_VERSION.equals(getSchemaVersion())) {
+        if (!StationXMLTagNames.CURRENT_SCHEMA_VERSION.equals(getSchemaVersion())) {
             return false;
         }
         return true;
     }
-    
+
     public void setResponse(CloseableHttpResponse response) {
         this.response = response;
     }
-    
+
     /**
      * Where input stream came from, so can be closed at end
      */
@@ -207,9 +199,9 @@ public class FDSNStationXML {
     String created;
 
     String xmlSchemaLocation;
-    
+
     String schemaVersion;
-    
+
     NetworkIterator networks;
 
     private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FDSNStationXML.class);
@@ -221,7 +213,7 @@ public class FDSNStationXML {
             XMLEventReader r;
             r = factory.createXMLEventReader(url.toString(), url.openStream());
             return new FDSNStationXML(r);
-        } catch(Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException("Should not happen", e);
         }
     }
@@ -254,17 +246,14 @@ public class FDSNStationXML {
     public static FDSNStationXML loadStationXML(String filename) throws XMLStreamException, IOException, SeisFileException {
         return loadStationXML(new FileInputStream(filename));
     }
-    
+
     public static void main(String[] args) throws XMLStreamException, IOException, SeisFileException, JSAPException {
         final FDSNStationXML stationXml = loadStationXML(args[0]);
         StationClient sc = new StationClient(new String[0]) {
-            public void run()  {
+            public void run() {
                 try {
                     handleResults(stationXml);
-                } catch(XMLStreamException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                } catch(SeisFileException e) {
+                } catch (XMLStreamException | SeisFileException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();
                 }
@@ -273,12 +262,14 @@ public class FDSNStationXML {
         sc.run();
     }
 
-    /** this is mainly so that the resources associated with the xml reader
-     * are no garbage collected. Was having trouble with connections being
-     * closed in the middle of reading xml, I believe due to finalize() and
-     * adding this seemed to fixe it.
+    /**
+     * this is mainly so that the resources associated with the xml reader are
+     * no garbage collected. Was having trouble with connections being closed in
+     * the middle of reading xml, I believe due to finalize() and adding this
+     * seemed to fixe it.
      */
     FDSNStationQuerier fdsnStationQuerier;
+
     public void setQuerier(FDSNStationQuerier fdsnStationQuerier) {
         this.fdsnStationQuerier = fdsnStationQuerier;
     }


### PR DESCRIPTION
Hi Dr. Crotwell,

This pull request contains three commits. 

The first two commits add loadStationXML methods that take in an InputStream and a Reader instance, and refactors the filename method to use the new InputStream version to avoid code duplication. The motivation for these changes was to be able to use your library with StationXML data not necessarily stored in a file but as a blob somewhere else (Hadoop HDFS, Oracle, etc.).

The third commit contains source formatting done by by IDE, as well as code changes to eliminate compiler warnings. 

Thanks,
Steven Magana-Zook
Lawrence Livermore National Laboratory